### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Contributing
 
 If you experience problems with cricket, `log them on GitHub`_. If you want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Read The Docs: http://cricket.readthedocs.org
+.. _Read The Docs: https://cricket.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers

--- a/cricket/view.py
+++ b/cricket/view.py
@@ -603,7 +603,7 @@ class MainWindow(object):
 
     def cmd_cricket_docs(self):
         "Show the Cricket documentation"
-        webbrowser.open_new('http://cricket.readthedocs.org/')
+        webbrowser.open_new('https://cricket.readthedocs.io/')
 
     ######################################################
     # GUI Callbacks


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.