### PR TITLE
Version reference was invalid

### DIFF
--- a/cricket/main.py
+++ b/cricket/main.py
@@ -36,7 +36,7 @@ def main(Model):
     # Check the shortcut options
     if options.version:
         import cricket
-        print(cricket.VERSION)
+        print(cricket.__version__)
         return
 
     # Set up the root Tk context


### PR DESCRIPTION
I was looking at https://github.com/pybee/cricket/issues/38

It seems you added python 3 support as my basic poking around worked fine. But I did notice that the command `cricket-unittest --version` was failing because of a bad reference

Nice talking to you yesterday at your Pycon Booth :-)