### PR TITLE
Change type of error message to str instead of bytes.

### DIFF
--- a/cricket/executor.py
+++ b/cricket/executor.py
@@ -240,7 +240,7 @@ class Executor(EventSource):
         elif stopped:
             # Suite has stopped producing output.
             if self.error_buffer:
-                self.emit('suite_error', error=b'\n'.join(self.error_buffer))
+                self.emit('suite_error', error='\n'.join(self.error_buffer))
             else:
                 self.emit('suite_error', error='Test output ended unexpectedly')
 


### PR DESCRIPTION
If the test suite crashed (for instance, when testing a django project, if there was a migration conflict), cricket would fail with a traceback on this line. Verified that the fix works in Python 3.5 and 2.7.

Example of the traceback cricket would throw in this instance:
Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib/python3.5/tkinter/__init__.py", line 1553, in __call__
    return self.func(*args)
  File "/usr/lib/python3.5/tkinter/__init__.py", line 599, in callit
    func(*args)
  File "/home/cmays/Projects/cricket/cricket/cricket/view.py", line 787, in on_testProgress
    if self.executor and self.executor.poll():
  File "/home/cmays/Projects/cricket/cricket/cricket/executor.py", line 243, in poll
    self.emit('suite_error', error=b'\n'.join(self.error_buffer))
TypeError: sequence item 0: expected a bytes-like object, str found


Signed-off-by: Charlotte Mays <charlotte.ann.mays@gmail.com>